### PR TITLE
Fix handling of string entries under Python 2

### DIFF
--- a/networktables2/networktablenode.py
+++ b/networktables2/networktablenode.py
@@ -81,7 +81,7 @@ class NetworkTableNode:
                 type = DefaultEntryTypes.BOOLEAN
             elif isinstance(value, (float, int)):
                 type = DefaultEntryTypes.DOUBLE
-            elif isinstance(value, str):
+            elif isinstance(value, basestring):
                 type = DefaultEntryTypes.STRING
             elif isinstance(value, ComplexData):
                 type = value.getType()


### PR DESCRIPTION
We ran into this when testing pynetworktables2js - `putValue()` was failing for strings under Python 2 because they're sent across as unicode strings. I'm unsure if there's any case where byte strings would be sent across in either version, so I just changed this to check for `str` in Python 3 and `unicode` in Python 2. (Using six might be cleaner for this, but I didn't feel a need to introduce another dependency for something this trivial.)