### PR TITLE
ntcore.value: Use unicode strings in Python 2

### DIFF
--- a/networktables/util.py
+++ b/networktables/util.py
@@ -1,7 +1,7 @@
 
 from .networktables import NetworkTables
 
-from ntcore.value import Value, stringtype
+from ntcore.value import Value
 
 __all__ = [
     'ntproperty',

--- a/ntcore/support/compat.py
+++ b/ntcore/support/compat.py
@@ -20,11 +20,13 @@ except ImportError:
 
 if sys.version_info[0] <= 2:
     range = xrange
-    stringtype = basestring
+    basestring = basestring
+    unicode = unicode
     PY2 = True
 else:
     range = range
-    stringtype = str
+    basestring = str
+    unicode = str
     PY2 = False
     
 #

--- a/ntcore/value.py
+++ b/ntcore/value.py
@@ -23,7 +23,7 @@ from .constants import (
     NT_RPC,
 )
 
-from .support.compat import stringtype
+from .support.compat import basestring, unicode
 
 ValueType = namedtuple('Value', ['type', 'value'])
 
@@ -48,7 +48,7 @@ class Value(object):
 
     @staticmethod
     def makeString(value):
-        return ValueType(NT_STRING, str(value))
+        return ValueType(NT_STRING, unicode(value))
     
     @staticmethod
     def makeRaw(value):
@@ -66,7 +66,7 @@ class Value(object):
     
     @staticmethod
     def makeStringArray(value):
-        return ValueType(NT_STRING_ARRAY, tuple(str(v) for v in value))
+        return ValueType(NT_STRING_ARRAY, tuple(unicode(v) for v in value))
 
     @staticmethod
     def makeRpc(value):
@@ -78,7 +78,7 @@ class Value(object):
             return Value.makeBoolean
         elif isinstance(value, (int, float)):
             return Value.makeDouble
-        elif isinstance(value, stringtype):
+        elif isinstance(value, basestring):
             return Value.makeString
         elif isinstance(value, bytes):
             return Value.makeRaw
@@ -94,7 +94,7 @@ class Value(object):
                 return Value.makeBooleanArray
             elif isinstance(first, (int, float)):
                 return Value.makeDoubleArray
-            elif isinstance(first, (stringtype)):
+            elif isinstance(first, basestring):
                 return Value.makeStringArray
             else:
                 raise ValueError("Can only use lists of bool/int/float/strings")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -153,11 +153,12 @@ def doc(nt):
 def do(nt1, nt2, t):
         
     t1 = nt1.getTable(t)
-    with nt2.expect_changes(7):
+    with nt2.expect_changes(8):
         t1.putBoolean('bool', True)
         t1.putNumber('number1', 1)
         t1.putNumber('number2', 1.5)
         t1.putString('string', 'string')
+        t1.putString('unicode', u'\xA9')  # copyright symbol
         t1.putBooleanArray('ba', (True, False))
         t1.putNumberArray('na', (1, 2))
         t1.putStringArray('sa', ('s', 't'))
@@ -167,16 +168,18 @@ def do(nt1, nt2, t):
     assert t2.getNumber('number1') == 1
     assert t2.getNumber('number2') == 1.5
     assert t2.getString('string') == 'string'
+    assert t2.getString('unicode') == u'\xA9'  # copyright symbol
     assert t2.getBooleanArray('ba') == (True, False) 
     assert t2.getNumberArray('na') == (1, 2)
     assert t2.getStringArray('sa') == ('s', 't')
     
     # Value testing
-    with nt2.expect_changes(5):
+    with nt2.expect_changes(6):
         t1.putValue('v_b', False)
         t1.putValue('v_n1', 2)
         t1.putValue('v_n2', 2.5)
         t1.putValue('v_s', 'ssss')
+        t1.putValue('v_s2', u'\xA9')
         
         t1.putValue('v_v', 0)
         
@@ -185,14 +188,16 @@ def do(nt1, nt2, t):
     assert t2.getNumber('v_n1') == 2
     assert t2.getNumber('v_n2') == 2.5
     assert t2.getString('v_s') == 'ssss'
+    assert t2.getString('v_s2') == u'\xA9'
     assert t2.getValue('v_v') == 0
     
     # Ensure that updating values work!
-    with nt2.expect_changes(7):
+    with nt2.expect_changes(8):
         t1.putBoolean('bool', False)
         t1.putNumber('number1', 2)
         t1.putNumber('number2', 2.5)
         t1.putString('string', 'sss')
+        t1.putString('unicode', u'\u2122')  # (tm)
         t1.putBooleanArray('ba', (False, True, False))
         t1.putNumberArray('na', (2, 1))
         t1.putStringArray('sa', ('t', 's'))
@@ -202,6 +207,7 @@ def do(nt1, nt2, t):
     assert t2.getNumber('number1') == 2
     assert t2.getNumber('number2') == 2.5
     assert t2.getString('string') == 'sss'
+    assert t2.getString('unicode') == u'\u2122'
     assert t2.getBooleanArray('ba') == (False, True, False) 
     assert t2.getNumberArray('na') == (2, 1)
     assert t2.getStringArray('sa') == ('t', 's')

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -148,3 +148,12 @@ def test_StringArrayComparison():
     # different size
     v2 = Value.makeStringArray(["hello", "goodbye"])
     assert v1 != v2
+
+#
+# Additional Python tests
+#
+
+def test_unicode():
+    # copyright symbol
+    v1 = Value.makeString(u'\xA9')
+    assert v1.value == u'\xA9'


### PR DESCRIPTION
Fixes #36.