### PR TITLE
Fixes ValueError

### DIFF
--- a/networktables/networktables.py
+++ b/networktables/networktables.py
@@ -583,6 +583,9 @@ class NetworkTables:
             valuefn = Value.getFactory(defaultValue)
             cls._api.setEntryValue(key, valuefn(defaultValue))
             value = defaultValue
+        elif not writeDefault:
+            value = value.value
+            valuefn = Value.getFactory(value)
         else:
             valuefn = Value.getFactory(value)
         


### PR DESCRIPTION
When attempting to create an auto-update value that does not overwrite the existing network table value, the value object was passed to the factory instead of that value itself.