### PR TITLE
ntcore.value: Accept bytearray as raw values

### DIFF
--- a/ntcore/value.py
+++ b/ntcore/value.py
@@ -80,7 +80,7 @@ class Value(object):
             return Value.makeDouble
         elif isinstance(value, basestring):
             return Value.makeString
-        elif isinstance(value, bytes):
+        elif isinstance(value, (bytes, bytearray)):
             return Value.makeRaw
         
         # Do best effort for arrays, but can't catch all cases

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -157,3 +157,10 @@ def test_unicode():
     # copyright symbol
     v1 = Value.makeString(u'\xA9')
     assert v1.value == u'\xA9'
+
+
+def test_bytearray():
+    v1 = Value.makeRaw(bytearray(b'\x01\x02\x00'))
+    assert v1.type == NT_RAW
+    assert v1.value == bytearray(b'\x01\x02\x00')
+    assert v1.value == b'\x01\x02\x00'


### PR DESCRIPTION
This allows for the creation of raw values in Python 2.