### PR TITLE
Update testing-requirements.txt

### DIFF
--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest>=3.0
 coverage
 mock
-monotonic
+monotonic; python_version < '3.3'


### PR DESCRIPTION
This fixes the bustage in [Travis job 184.2](https://travis-ci.org/robotpy/pynetworktables/jobs/280273298), and avoids unnecessarily installing the monotonic backport on Python 3.