### PR TITLE
Make NetworkTablesEntry actually unhashable

### DIFF
--- a/networktables/entry.py
+++ b/networktables/entry.py
@@ -479,10 +479,6 @@ class NetworkTableEntry(object):
     
     def __bool__(self):
         raise TypeError("< not allowed on NetworkTableEntry objects. Use the .value attribute instead")
-    
-    def __hash__(self):
-        raise TypeError("__hash__ not allowed on NetworkTableEntry objects")
-    
+
     def __repr__(self):
         return '<NetworkTableEntry: %s>' % (self._value.__repr__(), )
-    


### PR DESCRIPTION
With a `C.__hash__()` method, `issubclass(C, collections.abc.Hashable)`
returns True.  Overriding `__eq__()` causes `__hash__` to be set to None,
which gives us the behaviour that we want.