### PR TITLE
Fix NetworkTables.setServerTeam()

### DIFF
--- a/ntcore/api.py
+++ b/ntcore/api.py
@@ -232,8 +232,8 @@ class NtCoreApi(object):
     def setServer(self, server_or_servers):
         self.dispatcher.setServer(server_or_servers)
         
-    def setServerTeam(self, teamNumber):
-        self.dispatcher.setServerTeam(teamNumber)
+    def setServerTeam(self, teamNumber, port):
+        self.dispatcher.setServerTeam(teamNumber, port)
     
     def startDSClient(self, port):
         self.ds_client.start(port)
@@ -276,5 +276,3 @@ class NtCoreApi(object):
     
     def loadEntries(self, filename, prefix):
         return self.storage.loadEntries(filename=filename, prefix=prefix)
-    
-        


### PR DESCRIPTION
This fixes NetworkTables.startClientTeam().

STR:
```python
from networktables import NetworkTables
NetworkTables.startClientTeam(4774)
```
```pytb
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "~/dev/frc/robotpy/pynetworktables/networktables/instance.py", line 475, in startClientTeam
    self.setServerTeam(team, port)
  File "~/dev/frc/robotpy/pynetworktables/networktables/instance.py", line 514, in setServerTeam
    self._api.setServerTeam(team, port)
TypeError: setServerTeam() takes 2 positional arguments but 3 were given
```