### PR TITLE
Added method to NetworkTable class to check for value type associated…

### DIFF
--- a/networktables/networktable.py
+++ b/networktables/networktable.py
@@ -868,3 +868,19 @@ class NetworkTable:
         return self._inst.getGlobalAutoUpdateValue(
             self._path + key, defaultValue, writeDefault
         )
+
+    def getValueType(self, key):
+        """Gets the value type associated with a key.
+        
+        :param key: the key of the value type to look up
+        :type key: str
+        
+        :returns: the value type associated with the given key
+        :rtype: bytes
+
+        """
+        path = self._path + key
+        value = self._api.getEntryValue(path)
+        if not value:
+            return None
+        return value.type


### PR DESCRIPTION
… with a key. Using pynetworktables2js I'm not able to tell what type an empty array is (whether it's a string, bool, or number array), so I want to send the type of the variable along with its value and key through the websocket.