### PR TITLE
Doubled the timeout for multi-threaded connect operation to overcome …

### DIFF
--- a/_pynetworktables/_impl/tcpsockets/tcp_connector.py
+++ b/_pynetworktables/_impl/tcpsockets/tcp_connector.py
@@ -40,7 +40,7 @@ class TcpConnector(object):
                     th.start()
                     self.threads[item] = th
 
-            self.cond.wait(self.timeout)
+            self.cond.wait(2*self.timeout)
             self.active = False
 
             result = self.result


### PR DESCRIPTION
Doubled the timeout for multi-threaded connect operation to overcome Windows create_connection behavior described in Issue #116 and Issue #84.

Tested on both my Windows machines and it solves the problem. There doesn't seem to be any risk that it would break on other platforms or for other kinds of connection requests.